### PR TITLE
Feature: add appointment date filters

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
   "rules": {
     "@next/next/no-img-element": "off",
     "jsx-a11y/alt-text": "off",
-    "react/no-unescaped-entities": "off"
+    "react/no-unescaped-entities": "off",
+    " react-hooks/exhaustive-deps": "off"
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 
 # Adjust NODE_VERSION as desired
 ARG NODE_VERSION=20.15.0
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
 FROM node:${NODE_VERSION}-slim as base
 
 LABEL fly_launch_runtime="Next.js"
@@ -27,6 +29,8 @@ RUN npm ci --include=dev
 # Copy application code
 COPY --link . .
 
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
 # Build application
 RUN npm run build
 

--- a/app/dashboard/appointments/page.tsx
+++ b/app/dashboard/appointments/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import AppointmentRequests from "@/components/dashboard/appointments/appointmentRequests";
 import CancelledAppointments from "@/components/dashboard/appointments/cancelledAppointments";
+import { AppointmentCalendarContext, DateValue } from "@/components/dashboard/appointments/helpers";
 import UpcomingAppointments from "@/components/dashboard/appointments/upcomingAppointments";
 import Navbar from "@/components/navbar";
 import TopBar from "@/components/topbar";
@@ -10,91 +11,92 @@ import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import { AuthContext } from "../layout";
 
-type ValuePiece = Date | null;
-type DateValue = ValuePiece | [ValuePiece, ValuePiece];
+
 
 export default function AppointmentsPage() {
   const currentUser = useContext(AuthContext);
   const [date, setDate] = useState<DateValue>(new Date());
 
   return (
-    <main className=" bg-primary-500 flex">
-      <div className="py-[30px] w-[230px]">
-        <Navbar />
-      </div>
-      <div className="bg-[#F8F8F8] p-8 rounded-l-[50px] w-full overflow-hidden">
-        <TopBar
-          firstName={currentUser?.firstName ?? ""}
-          image={currentUser?.image ?? ""}
-        />
-        <div className="flex mb-12 mt-6 gap-8">
-          <div className="col flex-[2] overflow-hidden flex flex-col">
-            <h1 className="text-xl mb-6">
-              Good morning &nbsp;
-              <span className="font-semibold text-3xl text-primary-500">
-                Dr. {currentUser?.firstName}!
-              </span>
-            </h1>
-            <UpcomingAppointments />
-          </div>
-          <div className="col max-w-[320px]">
-            <div className="bg-white rounded-xl shadow-md p-5 mb-3">
-              <div className="flex justify-between items-center mb-3">
-                <h5 className="font-semibold">Calendar</h5>
-                <svg
-                  width="18"
-                  height="18"
-                  viewBox="0 0 18 18"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M4.73976 7.68237C5.08716 7.3325 5.65273 7.3315 6.00137 7.68014L8.68446 10.3632C9.10984 10.7886 9.79952 10.7886 10.2249 10.3632L12.908 7.68014C13.2566 7.3315 13.8222 7.3325 14.1696 7.68237V7.68237C14.5153 8.0305 14.5143 8.59263 14.1674 8.93953L10.2249 12.882C9.79952 13.3074 9.10984 13.3074 8.68446 12.882L4.74198 8.93953C4.39507 8.59263 4.39408 8.0305 4.73976 7.68237V7.68237Z"
-                    fill="#5F647E"
-                  />
-                </svg>
-              </div>
-              <div>
-                <Calendar
-                  className={"calendar"}
-                  locale="en-US"
-                  onChange={setDate}
-                />
-              </div>
-              <div className="flex justify-between items-center pt-4">
-                <p className="font-bold">Upcoming</p>
-                <Link
-                  href={""}
-                  className="text-[12px] text-[#1A71FF] mr-[10px]"
-                >
-                  View all
-                </Link>
-              </div>
-              <div className="flex gap-[30px] items-center mt-[20px] p-1 bg-[#F0F9FD] rounded-xl">
-                <div className="ml-1 p-2 bg-gradient-to-tr from-[#1A71FF45] to-[#1A71FF] rounded-full h-[40px] w-[40px] flex items-center justify-center">
-                  <p className="font-bold text-white">M</p>
+    <AppointmentCalendarContext.Provider value={{ date, setDate }}>
+      <main className=" bg-primary-500 flex">
+        <div className="py-[30px] w-[230px]">
+          <Navbar />
+        </div>
+        <div className="bg-[#F8F8F8] p-8 rounded-l-[50px] w-full overflow-hidden">
+          <TopBar
+            firstName={currentUser?.firstName ?? ""}
+            image={currentUser?.image ?? ""}
+          />
+          <div className="flex mb-12 mt-6 gap-8">
+            <div className="col flex-[2] overflow-hidden flex flex-col">
+              <h1 className="text-xl mb-6">
+                Good morning &nbsp;
+                <span className="font-semibold text-3xl text-primary-500">
+                  Dr. {currentUser?.firstName}!
+                </span>
+              </h1>
+              <UpcomingAppointments />
+            </div>
+            <div className="col max-w-[320px]">
+              <div className="bg-white rounded-xl shadow-md p-5 mb-3">
+                <div className="flex justify-between items-center mb-3">
+                  <h5 className="font-semibold">Calendar</h5>
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 18 18"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M4.73976 7.68237C5.08716 7.3325 5.65273 7.3315 6.00137 7.68014L8.68446 10.3632C9.10984 10.7886 9.79952 10.7886 10.2249 10.3632L12.908 7.68014C13.2566 7.3315 13.8222 7.3325 14.1696 7.68237V7.68237C14.5153 8.0305 14.5143 8.59263 14.1674 8.93953L10.2249 12.882C9.79952 13.3074 9.10984 13.3074 8.68446 12.882L4.74198 8.93953C4.39507 8.59263 4.39408 8.0305 4.73976 7.68237V7.68237Z"
+                      fill="#5F647E"
+                    />
+                  </svg>
                 </div>
                 <div>
-                  <p className="text-[14px] font-semibold">
-                    Monthly doctor's meet
-                  </p>
-                  <p className="text-[12px] text-[#0D0D0D60]">
-                    8 April, 2021 | 04:00 PM
-                  </p>
+                  <Calendar
+                    className={"calendar"}
+                    locale="en-US"
+                    onChange={setDate}
+                  />
+                </div>
+                <div className="flex justify-between items-center pt-4">
+                  <p className="font-bold">Upcoming</p>
+                  <Link
+                    href={""}
+                    className="text-[12px] text-[#1A71FF] mr-[10px]"
+                  >
+                    View all
+                  </Link>
+                </div>
+                <div className="flex gap-[30px] items-center mt-[20px] p-1 bg-[#F0F9FD] rounded-xl">
+                  <div className="ml-1 p-2 bg-gradient-to-tr from-[#1A71FF45] to-[#1A71FF] rounded-full h-[40px] w-[40px] flex items-center justify-center">
+                    <p className="font-bold text-white">M</p>
+                  </div>
+                  <div>
+                    <p className="text-[14px] font-semibold">
+                      Monthly doctor's meet
+                    </p>
+                    <p className="text-[12px] text-[#0D0D0D60]">
+                      8 April, 2021 | 04:00 PM
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div className="flex gap-8 mb-8">
-          <div className="col flex-[1] overflow-hidden">
-            <AppointmentRequests />
+          <div className="flex gap-8 mb-8">
+            <div className="col flex-[1] overflow-hidden">
+              <AppointmentRequests />
+            </div>
+            <div className="col flex-[1] overflow-hidden">
+              <CancelledAppointments />
+            </div>
           </div>
-          <div className="col flex-[1] overflow-hidden">
-            <CancelledAppointments />
-          </div>
         </div>
-      </div>
-    </main>
+      </main>
+    </AppointmentCalendarContext.Provider>
   );
 }

--- a/components/dashboard/appointments/cancelledAppointments.tsx
+++ b/components/dashboard/appointments/cancelledAppointments.tsx
@@ -4,12 +4,15 @@ import { createClient } from "@/utils/supabase/client";
 import { useContext, useEffect, useState } from "react";
 import {
   Appointment,
+  AppointmentCalendarContext,
   getColorByPackage,
+  getDate,
   Patient,
-} from "./upcomingAppointments";
+} from "./helpers";
 
 export default function CancelledAppointments() {
   const currentUser = useContext(AuthContext);
+  const { date } = useContext(AppointmentCalendarContext);
   const [appointments, setAppointments] = useState<Appointment[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -33,6 +36,7 @@ export default function CancelledAppointments() {
         )
         .eq("doctor_id", currentUser.id)
         .eq("status", "Cancelled")
+        .gt("appointment_date", getDate(date).toISOString())
         .order("appointment_date", { ascending: true })
         .limit(5);
 
@@ -47,20 +51,12 @@ export default function CancelledAppointments() {
       }
     };
     fetchAppointments();
-  }, [currentUser]);
+  }, [currentUser, date]);
 
   return (
     <section className="p-6 bg-white rounded-2xl shadow-md mb-3">
       <div className="flex flex-row">
         <h4 className="text-lg font-semibold flex-1">Cancelled Appointments</h4>
-        <div className="w-32">
-          <select className="bg-transparent focus:outline-none w-full">
-            <option>Today</option>
-            <option>Tomorrow</option>
-            <option>This week</option>
-            <option>This month</option>
-          </select>
-        </div>
       </div>
       <div className={"overflow-auto" + (loading ? " my-24" : " my-8")}>
         {loading && appointments.length == 0 && (
@@ -71,7 +67,8 @@ export default function CancelledAppointments() {
             No appointments found
           </p>
         )}
-        {!loading && appointments.length > 0 &&
+        {!loading &&
+          appointments.length > 0 &&
           appointments.map((appointment) => {
             const color = getColorByPackage(appointment.package);
             return (

--- a/components/dashboard/appointments/helpers.ts
+++ b/components/dashboard/appointments/helpers.ts
@@ -1,0 +1,111 @@
+import { UUID } from "crypto";
+import { createContext } from "react";
+
+export const AppointmentCalendarContext = createContext<{
+  date: DateValue;
+  setDate: (date: DateValue) => void;
+}>({
+  date: new Date(),
+  setDate: () => {},
+});
+
+type ValuePiece = Date | null;
+export type DateValue = ValuePiece | [ValuePiece, ValuePiece];
+
+export type Patient = {
+  id: UUID;
+  full_name: string;
+  nickname: string;
+  email: string;
+  phone: string;
+  gender: string;
+  date_of_birth: string;
+  problem: string;
+};
+
+export type Appointment = {
+  id: UUID;
+  patient_id: UUID;
+  doctor_id: UUID;
+  date: string;
+  time: string;
+  status: "Booked" | "Approved" | "Completed" | "Cancelled" | "Rescheduled";
+  package: "Messaging" | "Video Call" | "Voice Call";
+  duration: string;
+  amount: string;
+  cancellation_reason: string;
+  patient: Patient;
+};
+
+const colors = [
+  {
+    type: "Messaging",
+    light: "#fdd2e7",
+    dark: "#F62088",
+  },
+  {
+    type: "Video Call",
+    light: "#ccccff",
+    dark: "#6666ff",
+  },
+  {
+    type: "Voice Call",
+    light: "#cfe7e6",
+    dark: "#128983",
+  },
+];
+
+export const getColorByPackage = (type: string) => {
+  return colors.find((color) => color.type === type);
+};
+
+export const getPatientName = (patient: Patient) =>
+  patient.full_name + " " + patient.nickname;
+
+export const getAppointmentTime = (time: string) => {
+  const [hours, minutes] = time.split(":");
+  return `${hours}:${minutes} ${parseInt(hours) >= 12 ? "PM" : "AM"}`;
+};
+
+export const getAppointmentDate = (date: string) =>
+  new Date(date).toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+export const getPatientAge = (dateOfBirth: string) => {
+  if (!dateOfBirth) return "N/A";
+  const dob = new Date(dateOfBirth);
+  const diffMs = Date.now() - dob.getTime();
+  const ageDt = new Date(diffMs);
+  return Math.abs(ageDt.getUTCFullYear() - 1970);
+};
+
+export const getAppointmentDuration = (time: string, duration: string) => {
+  const [hours, minutes] = time.split(":");
+  const [count, identifier] = duration.split(" ");
+  const totalMinutes = parseInt(hours) * 60 + parseInt(minutes);
+  let endMinutes = totalMinutes;
+
+  if (identifier === "minutes") {
+    endMinutes += parseInt(count);
+  } else {
+    endMinutes += parseInt(count) * 60;
+  }
+
+  const endHours = Math.floor(endMinutes / 60);
+  const endMinutesRemainder = endMinutes % 60;
+
+  return `${hours}:${minutes} - ${endHours}:${endMinutesRemainder} ${
+    endHours >= 12 ? "PM" : "AM"
+  } (${duration})`;
+};
+
+export const getDate = (date: DateValue) => {
+  const d = new Date(date?.toString() ?? "");
+  return new Date(
+    Date.parse(`${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()} 00:00:00`)
+  );
+};

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -64,14 +64,6 @@ export default function Navbar() {
           </div>
           <span className="desc font-semibold">Messages</span>
         </Link>
-        <div className="flex gap-[20px] items-center hover:bg-[#FFFFFF40] rounded-xl py-2 px-4">
-          <div className="w-[30px]">
-            <span>
-              <Image src={require("../assets/icons/reports.svg")} alt="home" />{" "}
-            </span>
-          </div>
-          <span className="desc font-semibold">Reports</span>
-        </div>
         <Link href="/dashboard/profile" className="flex gap-[20px] items-center hover:bg-[#FFFFFF40] rounded-xl py-2 px-4">
           <div className="w-[30px]">
             <span>


### PR DESCRIPTION
#### What does this PR do?

This PR includes implementation of appointments filtering using the calendar UI

#### Description of Task to be completed?

- Fetch appointments using the date selected in calendar

#### How should this be manually tested?

The logic is that the app selects a max of 5 appointments after the selected date in the calendar. If you have an appointment in your dashboard check the date and try to select a later date, It should reload and show only appointments after the selected date. Try selecting an earlier date and it should load it again.

#### Any background context you want to provide?

N/A

#### What are the relevant pivotal tracker/Trello stories?

N/A

#### Screenshots (if appropriate)

N/A

#### Questions:

N/A